### PR TITLE
Double check GPS sensor(s) using the WiFi sensor(s) on departure

### DIFF
--- a/standardCombinedPresenceInstance.groovy
+++ b/standardCombinedPresenceInstance.groovy
@@ -252,6 +252,17 @@ def presenceChangedHandler(evt) {
 			}
 		}
 		
+		if (anyHaveDeparted) {
+			// sometimes GPS sensors can be faulty and erroneously depart without actually physically leaving
+			// however, if there is at least one WiFi sensor, and that sensor can ping the device,
+			// then that device is for sure still present
+			// at worst, using the iPhone WiFi Presence Sensor driver, this value will be stale by 1 min
+			def wifiSensorsThinkOtherwise = inputSensorsWifi.any { it.currentValue("presence") == "present" }
+			if (wifiSensorsThinkOtherwise) {
+				log "GPS sensor(s) departed, but wifi sensor(s) can still detect the device"
+				anyHaveDeparted = false
+			}
+		}
 		newPresent = !(anyHaveDeparted)
 	}
 	


### PR DESCRIPTION
I noticed that the Hubitat app, for some reason, randomly says a device is not present and then a few seconds later says it's arrived.

I am not sure why this happens, but it is somewhat annoying. I realized that if the WiFi sensor can detect a device is present, then that should take priority over the GPS sensors.

Please consider this PR as a solution to this problem. The code will override the `anyHaveDeparted` variable if a WiFi sensor still thinks the device is present. I have only tested this with the [iPhone WiFi Presence Sensor](https://github.com/joelwetzel/Hubitat-iPhone-Presence-Sensor), but I presume it should work for others as well.