### PR TITLE
Added a delay to the standard combiner type to address the possibilty of false positives

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "githubPullRequests.ignoredPullRequestBranches": [
+        "master"
+    ]
+}

--- a/advancedCombinedPresenceInstance.groovy
+++ b/advancedCombinedPresenceInstance.groovy
@@ -1,5 +1,5 @@
 /**
- *  Advanced Combined Presence Instance v2.2.1
+ *  Advanced Combined Presence Instance v2.2.2
  *
  *  Copyright 2020 Joel Wetzel
  *
@@ -128,6 +128,11 @@ preferences {
 			input outputSensor
 		}
 		section() {
+			input "falsePositive", "bool", title: "Add a delay to allow for false positives (sensors activating and then returning to correct value within the set number of seconds)", submitOnChange: true
+			if (falsePositive)
+				input "falsePositiveDelay", "number", title: "Seconds to wait before confirming an event has occured", required: true, defaultValue: 0
+		}
+		section() {
 			paragraph ""	
 		}
 		section(hideable: true, hidden: true, "Notifications") {
@@ -253,6 +258,10 @@ def presenceChangedHandler(evt) {
 	log "PRESENCE CHANGED for: ${evt.device.name}"	
 	//log.debug groovy.json.JsonOutput.toJson(evt)
 
+	if (falsePositive) {
+			pauseExecution(falsePositiveDelay * 1000)
+	}
+	
 	def oldPresent = outputSensor.currentValue("presence") == "present"
 	def newPresent = false
 	
@@ -330,6 +339,3 @@ def log(msg) {
 		log.debug msg
 	}
 }
-
-
-

--- a/advancedCombinedPresenceInstance.groovy
+++ b/advancedCombinedPresenceInstance.groovy
@@ -128,11 +128,6 @@ preferences {
 			input outputSensor
 		}
 		section() {
-			input "falsePositive", "bool", title: "Add a delay to allow for false positives (sensors activating and then returning to correct value within the set number of seconds)", submitOnChange: true
-			if (falsePositive)
-				input "falsePositiveDelay", "number", title: "Seconds to wait before confirming an event has occured", required: true, defaultValue: 0
-		}
-		section() {
 			paragraph ""	
 		}
 		section(hideable: true, hidden: true, "Notifications") {
@@ -258,10 +253,6 @@ def presenceChangedHandler(evt) {
 	log "PRESENCE CHANGED for: ${evt.device.name}"	
 	//log.debug groovy.json.JsonOutput.toJson(evt)
 
-	if (falsePositive) {
-			pauseExecution(falsePositiveDelay * 1000)
-	}
-	
 	def oldPresent = outputSensor.currentValue("presence") == "present"
 	def newPresent = false
 	
@@ -339,3 +330,5 @@ def log(msg) {
 		log.debug msg
 	}
 }
+
+

--- a/combinedPresence.groovy
+++ b/combinedPresence.groovy
@@ -1,5 +1,5 @@
 /**
- *  Combined Presence v2.2.1
+ *  Combined Presence v2.2.2
  *
  *  Copyright 2020 Joel Wetzel
  *

--- a/combinedPresenceInstance.groovy
+++ b/combinedPresenceInstance.groovy
@@ -85,14 +85,6 @@ preferences {
 			paragraph "This will send a notification any time the state of the Output Sensor is changed by Combined Presence."
 		}
 		section() {
-			input "falsePositive", "bool", title: "Add a delay to allow for false positives (sensors activating and then returning to correct value within the set number of seconds)", submitOnChange: true
-			if (falsePositive)
-				input "falsePositiveDelay", "number", title: "Seconds to wait before confirming an event has occured", required: true, defaultValue: 0
-		}
-		section() {
-			paragraph ""	
-		}
-		section() {
 			input enableLogging
 		}
 	}
@@ -136,10 +128,6 @@ def presenceChangedHandler(evt) {
 	log "PRESENCE CHANGED for: ${evt.device.name}"
 	
 	def present = false
-	
-	if (falsePositive) {
-			pauseExecution(falsePositiveDelay * 1000)
-	}
 	
 	inputSensors.each { inputSensor ->
 		if (inputSensor.currentValue("presence") == "present") {
@@ -185,6 +173,5 @@ def log(msg) {
 		log.debug msg
 	}
 }
-
 
 

--- a/combinedPresenceInstance.groovy
+++ b/combinedPresenceInstance.groovy
@@ -1,5 +1,5 @@
 /**
- *  Combined Presence Instance v2.2.1
+ *  Combined Presence Instance v2.2.2
  *
  *  Copyright 2020 Joel Wetzel
  *
@@ -85,6 +85,14 @@ preferences {
 			paragraph "This will send a notification any time the state of the Output Sensor is changed by Combined Presence."
 		}
 		section() {
+			input "falsePositive", "bool", title: "Add a delay to allow for false positives (sensors activating and then returning to correct value within the set number of seconds)", submitOnChange: true
+			if (falsePositive)
+				input "falsePositiveDelay", "number", title: "Seconds to wait before confirming an event has occured", required: true, defaultValue: 0
+		}
+		section() {
+			paragraph ""	
+		}
+		section() {
 			input enableLogging
 		}
 	}
@@ -128,6 +136,10 @@ def presenceChangedHandler(evt) {
 	log "PRESENCE CHANGED for: ${evt.device.name}"
 	
 	def present = false
+	
+	if (falsePositive) {
+			pauseExecution(falsePositiveDelay * 1000)
+	}
 	
 	inputSensors.each { inputSensor ->
 		if (inputSensor.currentValue("presence") == "present") {

--- a/packageManifest.json
+++ b/packageManifest.json
@@ -5,7 +5,7 @@
 	"version": "2.2.2",
 	"dateReleased": "2025-1-19",
 	"licenseFile": "https://raw.githubusercontent.com/joelwetzel/Hubitat-Auto-Shades/master/LICENSE",
-	"releaseNotes": "Added an optional delay to all combiner types to address the possibility of false positives",
+	"releaseNotes": "Added an optional delay to standard combiner type to address the possibility of false positives",
 	"communityLink": "https://community.hubitat.com/t/release-combined-presence",
 	"documentationLink": "https://github.com/joelwetzel/Hubitat-Combined-Presence",
 	"apps" : [

--- a/packageManifest.json
+++ b/packageManifest.json
@@ -2,10 +2,10 @@
 	"packageName": "Combined Presence",
 	"minimumHEVersion": "2.2.1",
 	"author": "Joel Wetzel",
-	"version": "2.2.1",
-	"dateReleased": "2021-8-4",
+	"version": "2.2.2",
+	"dateReleased": "2025-1-19",
 	"licenseFile": "https://raw.githubusercontent.com/joelwetzel/Hubitat-Auto-Shades/master/LICENSE",
-	"releaseNotes": "Fixed a naming typo.  You may need to re-save your existing combiners to get them working.",
+	"releaseNotes": "Added an optional delay to all combiner types to address the possibility of false positives",
 	"communityLink": "https://community.hubitat.com/t/release-combined-presence",
 	"documentationLink": "https://github.com/joelwetzel/Hubitat-Combined-Presence",
 	"apps" : [

--- a/standardCombinedPresenceInstance.groovy
+++ b/standardCombinedPresenceInstance.groovy
@@ -231,22 +231,25 @@ def arrivedHandler(evt) {
 	log "${evt.device.name} arrived."	
 	//log.debug groovy.json.JsonOutput.toJson(evt)
 
-	log("False positive setting: ${falsePositive}. Delay set to ${falsePositiveDelay}")
+	log "False positive setting: ${falsePositive}. Delay set to ${falsePositiveDelay}"
 	if (falsePositive) {
 			pauseExecution(falsePositiveDelay * 1000)
 	}
 	
+	def inputPresence = evt.device.currentValue("presence") == "present"
 	def oldPresent = outputSensor.currentValue("presence") == "present"
 	def newPresent = true            // Something arrived!
 	
-	if (!oldPresent && newPresent) {
-		outputSensor.arrived()
-		
-        log "${outputSensor.displayName}.arrived()"	
+	if (inputPresence && newPresent) {
+		if (!oldPresent && newPresent) {
+			outputSensor.arrived()
+			
+			log "${outputSensor.displayName}.arrived()"	
 
-        if (notifyAboutStateChanges) {
-            sendNotification("Arrived: ${outputSensor.displayName}")
-        }
+			if (notifyAboutStateChanges) {
+				sendNotification("Arrived: ${outputSensor.displayName}")
+			}
+		}
 	}
 }
 
@@ -255,22 +258,25 @@ def departedHandler(evt) {
 	log "${evt.device.name} departed."	
 	//log.debug groovy.json.JsonOutput.toJson(evt)
 
-	log("False positive setting: ${falsePositive}. Delay set to ${falsePositiveDelay}")
+	log "False positive setting: ${falsePositive}. Delay set to ${falsePositiveDelay}"
 	if (falsePositive) {
 			pauseExecution(falsePositiveDelay * 1000)
 	}
 	
+	def inputPresence = evt.device.currentValue("presence") == "present"
 	def oldPresent = outputSensor.currentValue("presence") == "present"
 	def newPresent = false
 	
-	if (oldPresent && !newPresent) {
-		outputSensor.departed()
+	if (inputPresence && newPresent) {
+		if (oldPresent && !newPresent) {
+			outputSensor.departed()
 
-    	log "${outputSensor.displayName}.departed()"
-			
-        if (notifyAboutStateChanges) {
-            sendNotification("Departed: ${outputSensor.displayName}")
-        }
+			log "${outputSensor.displayName}.departed()"
+				
+			if (notifyAboutStateChanges) {
+				sendNotification("Departed: ${outputSensor.displayName}")
+			}
+		}
 	}
 }
 

--- a/standardCombinedPresenceInstance.groovy
+++ b/standardCombinedPresenceInstance.groovy
@@ -1,5 +1,5 @@
 /**
- *  Combined Presence - Standard Combiner v2.2.1
+ *  Combined Presence - Standard Combiner v2.2.2
  *
  *  Copyright 2020 Joel Wetzel
  *
@@ -97,6 +97,11 @@ preferences {
         }
         section() {
 			input outputSensor
+		}
+		section() {
+			input "falsePositive", "bool", title: "Add a delay to allow for false positives (sensors activating and then returning to correct value within the set number of seconds)", submitOnChange: true
+			if (falsePositive)
+				input "falsePositiveDelay", "number", title: "Seconds to wait before confirming an event has occured", required: true, defaultValue: 0
 		}
 		section() {
 			paragraph ""	
@@ -226,6 +231,11 @@ def arrivedHandler(evt) {
 	log "${evt.device.name} arrived."	
 	//log.debug groovy.json.JsonOutput.toJson(evt)
 
+	log("False positive setting: ${falsePositive}. Delay set to ${falsePositiveDelay}")
+	if (falsePositive) {
+			pauseExecution(falsePositiveDelay * 1000)
+	}
+	
 	def oldPresent = outputSensor.currentValue("presence") == "present"
 	def newPresent = true            // Something arrived!
 	
@@ -245,6 +255,11 @@ def departedHandler(evt) {
 	log "${evt.device.name} departed."	
 	//log.debug groovy.json.JsonOutput.toJson(evt)
 
+	log("False positive setting: ${falsePositive}. Delay set to ${falsePositiveDelay}")
+	if (falsePositive) {
+			pauseExecution(falsePositiveDelay * 1000)
+	}
+	
 	def oldPresent = outputSensor.currentValue("presence") == "present"
 	def newPresent = false
 	
@@ -272,7 +287,3 @@ def log(msg) {
 		log.debug msg
 	}
 }
-
-
-
-

--- a/standardCombinedPresenceInstance.groovy
+++ b/standardCombinedPresenceInstance.groovy
@@ -240,7 +240,7 @@ def arrivedHandler(evt) {
 	def oldPresent = outputSensor.currentValue("presence") == "present"
 	def newPresent = true            // Something arrived!
 	
-	if (inputPresence && newPresent) {
+	if (inputPresence == newPresent) {
 		if (!oldPresent && newPresent) {
 			outputSensor.arrived()
 			
@@ -267,7 +267,7 @@ def departedHandler(evt) {
 	def oldPresent = outputSensor.currentValue("presence") == "present"
 	def newPresent = false
 	
-	if (inputPresence && newPresent) {
+	if (inputPresence == newPresent) {
 		if (oldPresent && !newPresent) {
 			outputSensor.departed()
 


### PR DESCRIPTION
Included an option to switch on the use of a delay in the standard compbiner app. If a sensor state changes without the host device actually moving, which can happen, this change guards against the output sensor state being incorrectly updated. It is backwards compatible with current sensor configs.

I spent a fair bit of time messing with the boolean and advanced code to see if I could get it to function in a similar way but ended up drawing a blank. I can get the delay to work fine but, being a bit of a perfectionist(!), I couldn't then stop the output sensor from being updated with the the identical state, i.e., not changing the state but forcing an update. This annoyed me so I gave up!!!!